### PR TITLE
Trigger launcher feed re-sign after splice

### DIFF
--- a/.github/workflows/deploy-icarus.yml
+++ b/.github/workflows/deploy-icarus.yml
@@ -60,3 +60,12 @@ jobs:
 
       - name: Build client pack and update launcher feeds
         run: python3 scripts/build-client-pack.py
+
+      - name: Trigger launcher feed re-sign
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.LAUNCHER_DISPATCH_PAT }}
+        run: |
+          gh api -X POST /repos/zachyzissou/slurpnet-launcher/dispatches \
+            -f event_type=feed-updated \
+            -f "client_payload[source]=${{ github.repository }}"


### PR DESCRIPTION
## Summary

Adds a final step to `deploy-icarus.yml` that fires a `repository_dispatch` event back to `zachyzissou/slurpnet-launcher` after `scripts/build-client-pack.py` splices `launcher-servers.json`. The launcher repo owns the detached `.sig` next to that file; without an explicit dispatch the signature only refreshes via a 30-min cron, so clients see a payload-hash mismatch until the cron drifts to fire.

Pairs with the launcher-side handler in zachyzissou/slurpnet-launcher#730.

## Setup required

This repo needs a `LAUNCHER_DISPATCH_PAT` secret added before this merges:

- Fine-grained PAT
- `actions:write` scope
- Repository access scoped to `zachyzissou/slurpnet-launcher` only

The step is `if: success()` so failed deploys won't ping the launcher.

## Test plan

- [ ] Add `LAUNCHER_DISPATCH_PAT` secret to this repo
- [ ] Merge launcher PR #730 first so the `feed-updated` event_type has a handler
- [ ] Trigger an Icarus deploy and confirm the launcher's signing workflow runs within seconds
- [ ] Verify `launcher-servers.json.sig` payload hash matches the freshly spliced JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)