### PR TITLE
Use CROSS_REPO_TOKEN secret name (matches existing convention)

### DIFF
--- a/.github/workflows/deploy-icarus.yml
+++ b/.github/workflows/deploy-icarus.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Trigger launcher feed re-sign
         if: success()
         env:
-          GH_TOKEN: ${{ secrets.LAUNCHER_DISPATCH_PAT }}
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
         run: |
           gh api -X POST /repos/zachyzissou/slurpnet-launcher/dispatches \
             -f event_type=feed-updated \


### PR DESCRIPTION
Renamed `LAUNCHER_DISPATCH_PAT` → `CROSS_REPO_TOKEN` to match the secret name already in use across SlurpNet repos.

Slurpnet-launcher PR #730 (the dispatch handler) is already merged. The original PR #2 landed on main with the old name before this unification; this corrects it so the dispatch step actually authenticates against the provisioned `CROSS_REPO_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)