### PR TITLE
chore: migrate SlurpNet content origin naming

### DIFF
--- a/PACK_PUBLISHING.md
+++ b/PACK_PUBLISHING.md
@@ -36,7 +36,7 @@ python3 scripts/build-client-pack.py
 ```
 
 The script writes the zip, manifest, blob file, and feed metadata under
-`/mnt/cache/appdata/7dtd-downloads/api` by default.
+`/mnt/cache/appdata/slurpnet-content-origin/api` by default.
 
 Set `ICARUS_DOWNLOADS_DIR` to override the publish root for local dry runs.
 

--- a/docs/runner-persistence.md
+++ b/docs/runner-persistence.md
@@ -19,7 +19,7 @@ Unraid host, matching the current SlurpNet game-server pattern.
   - `/mnt/user/appdata/slurpnet-icarus-runner-work`
   - `/mnt/cache/appdata/icarus`
   - `/mnt/user/appdata/steamcmd`
-  - `/mnt/cache/appdata/7dtd-downloads`
+  - `/mnt/cache/appdata/slurpnet-content-origin`
 
 The workflow checks out the repo on the Unraid runner, validates the runner can
 see the live appdata and Docker daemon, renders production `ServerSettings.ini`

--- a/scripts/build-client-pack.py
+++ b/scripts/build-client-pack.py
@@ -13,7 +13,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PACK_PATH = ROOT / "pack.json"
 PAK_PATH = ROOT / "pak" / "SlurpNet.pak"
-DEFAULT_DOWNLOADS_DIR = Path("/mnt/cache/appdata/7dtd-downloads")
+DEFAULT_DOWNLOADS_DIR = Path(os.environ.get("SLURPNET_CONTENT_ROOT", "/mnt/cache/appdata/slurpnet-content-origin"))
 
 
 def sha256_file(path: Path) -> str:

--- a/scripts/reprovision-runner.sh
+++ b/scripts/reprovision-runner.sh
@@ -14,7 +14,7 @@ WORK_DIR="${ICARUS_RUNNER_WORK_DIR:-/mnt/user/appdata/slurpnet-icarus-runner-wor
 IMAGE="${ICARUS_RUNNER_IMAGE:-myoung34/github-runner:latest}"
 APPDATA="${ICARUS_APPDATA:-/mnt/cache/appdata/icarus}"
 STEAMCMD_ROOT="${ICARUS_STEAMCMD_ROOT:-/mnt/user/appdata/steamcmd}"
-DOWNLOADS_ROOT="${ICARUS_DOWNLOADS_ROOT:-/mnt/cache/appdata/7dtd-downloads}"
+DOWNLOADS_ROOT="${ICARUS_DOWNLOADS_ROOT:-${SLURPNET_CONTENT_ROOT:-/mnt/cache/appdata/slurpnet-content-origin}}"
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "ERROR: gh CLI is required" >&2


### PR DESCRIPTION
## Summary
- migrate active scripts/workflows/docs from the legacy `7dtd-downloads` naming to the shared `slurpnet-content-origin` root
- keep compatibility fallbacks where runtime container/path aliases may still be in transition
- preserve public URLs (`https://mods.slurpgg.net/...`) and existing feed/public-private split behavior

## Validation
- syntax checks for touched shell, Node, and Python scripts passed from the clean migration worktrees
- launcher: `npm run test:auth-service`, `npm run test:live-manifest-signing`, and `npm run validate:pack-contract` passed
- New Vegas Together: launcher integration, private distribution policy, support-debug validators passed; live target probe passed against `/mnt/cache/appdata/slurpnet-content-origin`
- Skyrim Together: pack, feed approval, and private distribution safety validators passed

## Notes
- Parent tracking issue: zachyzissou/slurpnet-launcher#978
- Live compatibility alias already exists: `/mnt/cache/appdata/slurpnet-content-origin -> /mnt/cache/appdata/7dtd-downloads`
- The final destructive rename is intentionally not part of this PR; that should happen after the compatibility branches land and publish paths are verified.
