### PR TITLE
Refresh Comfortable mod pak to w233

### DIFF
--- a/Mods/MODS.md
+++ b/Mods/MODS.md
@@ -9,19 +9,20 @@ use the identical merged pak.
 | Mod | Tier | Source URL | Notes |
 |---|---|---|---|
 | Icarus Plus | Comfortable | <https://www.nexusmods.com/icarus/mods/141?tab=files> file `1329` | Core quality-of-life baseline; downloaded as `Icarus Plus 3.0.4.150844` |
-| laanp-PetesBeaconTeleport | Comfortable | <https://github.com/laanp/Icarus_Mods_Separated/releases/download/v1_w229/laanp-PetesBeaconTeleport_v1_w229_P.pak> | Beacon teleport |
-| ItemFinder | Comfortable | <https://github.com/laanp/Icarus_Mods_Separated/releases/download/v1_w229/laanp-ItemFinder_v1_w229_P.pak> | Find dropped/stored items |
-| CaveMaster | Comfortable | <https://github.com/laanp/Icarus_Mods_Separated/releases/download/v1_w229/laanp-CaveMaster_v1_w229_P.pak> | Cave quality-of-life |
-| KeepTheTrees | Comfortable | <https://github.com/laanp/Icarus_Mods_Separated/releases/download/v1_w229/laanp-KeepTheTrees_v1_w229_P.pak> | Prevents tree-loss grind |
+| laanp-PetesBeaconTeleport | Comfortable | <https://github.com/laanp/Icarus_Mods_Separated/releases/download/v1_w233/laanp-PetesBeaconTeleport_v1_w233_P.pak> | Beacon teleport |
+| ItemFinder | Comfortable | <https://github.com/laanp/Icarus_Mods_Separated/releases/download/v1_w233/laanp-ItemFinder_v1_w233_P.pak> | Find dropped/stored items |
+| CaveMaster | Comfortable | <https://github.com/laanp/Icarus_Mods_Separated/releases/download/v1_w233/laanp-CaveMaster_v1_w233_P.pak> | Cave quality-of-life |
+| KeepTheTrees | Comfortable | <https://github.com/laanp/Icarus_Mods_Separated/releases/download/v1_w233/laanp-KeepTheTrees_v1_w233_P.pak> | Prevents tree-loss grind |
 | Food Buff 5x | Comfortable | <https://www.nexusmods.com/icarus/mods/123?tab=files> file `1417` | Longer food buff duration; downloaded as `Food Buff Duration 5x` |
 
 ## Current Build
 
 - Output: `pak/SlurpNet.pak`
-- SHA256: `e7fab780fdcbb51ea824426e687fcdc8846b30f43876418cd1ecc67f9da2e8b5`
-- Build host/tool: `repak v0.2.3` on SlurpNet Unraid
-- Merge policy: unpack all six paks, structured-merge duplicate JSON data
-  tables by `Rows[].Name`, then repack as one pak.
+- SHA256: `080dabdb93bca09b63a1d99a759ee66ecee7bd2d76b39f5c579027046cc9c8d5`
+- Build host/tool: `repak v0.2.3` (locally on macOS, case-sensitive APFS image)
+- Merge policy: unpack all six paks, canonicalize `Icarus/Content/data/` → `Icarus/Content/Data/`,
+  structured-merge duplicate JSON data tables by `Rows[].Name`, last-wins on binary
+  conflicts (priority order: IcarusPlus → laanp set → Food Buff 5x), then repack as V11.
 
 ## Merge Contract
 

--- a/pack.json
+++ b/pack.json
@@ -2,7 +2,7 @@
   "serverId": "icarus",
   "game": "Icarus",
   "distributionMode": "full_modpack",
-  "version": "2026.04.28a",
+  "version": "2026.05.23a",
   "zipName": "SlurpNet_Icarus_Mods.zip",
   "manifestName": "SlurpNet_Icarus_Mods-manifest.json",
   "blobPrefix": "icarus",


### PR DESCRIPTION
## Summary
- Bumps the 4 laanp QoL mods from `v1_w229` (Apr 24) to `v1_w233` (May 22) to match the current public Icarus build `3.0.11.152237`
- Rebuilds `pak/SlurpNet.pak` with the 6-mod Comfortable tier using `repak v0.2.3` locally on a case-sensitive APFS image
- Adds path canonicalization (`Icarus/Content/data/` → `Icarus/Content/Data/`) to the merge policy so IcarusPlus's data table contributions actually combine with laanp's, instead of sitting at separate case-variant paths that UE4-on-Windows would only half-load
- Documents the actual build host/tool in `MODS.md` (was aspirational before)

## Merge details
- Output: `pak/SlurpNet.pak`, **121 files**, **24,514,654 bytes**
- New SHA256: `080dabdb93bca09b63a1d99a759ee66ecee7bd2d76b39f5c579027046cc9c8d5`
- 6 JSON data tables structurally merged by `Rows[].Name` (4-way merge on `D_ProcessorRecipes` and `D_Itemable`, 3-way on the rest)
- 2 binary last-wins: `Banner.png`, `Readme.txt` → laanp-ItemFinder
- Nexus pins **unchanged**: mod 141 file 1329 (Icarus Plus), mod 123 file 1417 (Food Buff 5x) — both confirmed still latest via Nexus API

## Server state context
- The Icarus dedicated server itself was fixed earlier this session: SteamCMD update applied (buildid `23372579`), wine prefix wiped to resolve a 10-day-old deadlock, GAME_PARAMS port-binding bug fixed (was binding container 20008/20009 instead of 17777/27015), Unraid template `my-Icarus.xml` persisted. Server reached `OnServerStartedEmpty()` in ~90s. Backup at `/mnt/user/backups/icarus-phase-a/20260522-224650/`.

## Deployment requirement
`pak/SlurpNet.pak` is gitignored. **Before merging this PR**, the operator (or me, once Unraid is reachable) must stage the new pak at:
```
/mnt/user/appdata/slurpnet-icarus-runner-work/pak/SlurpNet.pak
```
via `scp -P 40222 pak/SlurpNet.pak root@192.168.225.196:/mnt/user/appdata/slurpnet-icarus-runner-work/pak/SlurpNet.pak`. The workflow's `actions/checkout@v6 clean: false` preserves it.

**Unraid is currently unreachable** — host appears powered off (ping/SSH/HTTP all timing out, ARP incomplete). Power it back on, SCP the pak, then merge.

## Test plan
- [ ] Unraid host back online
- [ ] `scp pak/SlurpNet.pak` to runner workspace at `/mnt/user/appdata/slurpnet-icarus-runner-work/pak/SlurpNet.pak`
- [ ] Merge PR → `deploy-icarus.yml` runs on `icarus-prod` runner
- [ ] Trigger `icarus-live-check.yml` from Actions UI and confirm:
  - container running
  - SHA matches `080dabdb…`
  - UDP listeners bound on host 20008/20009
- [ ] Stock-game client connect to `192.168.225.196:20008` with the launcher-installed pack; verify mod features (beacon teleport, item finder, cave QoL, kept trees, 5x food buff, Icarus Plus UI hooks)

## Risks
- **IcarusPlus is unmaintained.** File 1329 was built against game `3.0.4.150844` (~Feb 2026); server is now on `3.0.11.152237`. UI hooks usually survive game patches but compatibility is not guaranteed — chip for replacement research already spawned.
- **Lowercase `data/` paths removed.** The previous build had data tables at lowercase `data/`; this build canonicalizes to uppercase `Data/`. UE4 on Windows is case-insensitive so the game will load correctly, but if any client-side tooling has lowercase-only path expectations it may behave differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)