### PR TITLE
Reconcile port declarations with live deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,10 @@ APPDATA_ROOT=/mnt/cache/appdata/icarus
 STEAMCMD_ROOT=/mnt/user/appdata/steamcmd
 
 # Network
-GAME_PORT=17787
-QUERY_PORT=27017
+# Host-side published ports. The container internally binds Icarus defaults
+# (17777 game / 27015 query); these are what UniFi forwards to the Unraid host.
+GAME_PORT=20008
+QUERY_PORT=20009
 
 # Server identity
 SERVER_NAME="SlurpNet Icarus"

--- a/.github/workflows/icarus-live-check.yml
+++ b/.github/workflows/icarus-live-check.yml
@@ -14,7 +14,7 @@ jobs:
           timeout 15s docker ps --filter name=Icarus --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
           timeout 15s docker inspect Icarus --format 'name={{.Name}} image={{.Config.Image}} restart={{.HostConfig.RestartPolicy.Name}} cpuset={{.HostConfig.CpusetCpus}} memory={{.HostConfig.Memory}}'
           timeout 15s docker top Icarus -eo pid,ppid,comm,args | head -80 || true
-          timeout 15s ss -lunpt | grep -E ':(17787|27017)\b'
+          timeout 15s ss -lunpt | grep -E ':(20008|20009)\b'
           test -f /mnt/cache/appdata/icarus/Icarus/Content/Paks/mods/SlurpNet.pak
           sha256sum /mnt/cache/appdata/icarus/Icarus/Content/Paks/mods/SlurpNet.pak
           timeout 15s docker logs --tail 160 Icarus || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ Rules:
 - Do not commit `pak/*.pak`.
 - Keep `pak/SlurpNet.pak` as the only deployable pak filename.
 - Keep the launcher archive path at `Icarus/Content/Paks/mods/SlurpNet.pak`.
-- Keep Icarus default ports remapped to `17787/UDP` and `27017/UDP`.
+- Keep Icarus host-side ports at `20008/UDP` (game) and `20009/UDP` (query);
+  the container binds Icarus defaults `17777`/`27015` internally.
 - Do not deploy separate Icarus paks. Server and clients require one identical
   merged pak.
 - Do not deploy or push without explicit operator approval.

--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ tag did not resolve during scaffolding. The current ich777 Unraid template uses
 
 ## Ports
 
-| Purpose | Host port | Protocol |
-|---|---:|---|
-| Game | `17787` | UDP |
-| Query | `27017` | UDP |
+| Purpose | Host port | Container port | Protocol |
+|---|---:|---:|---|
+| Game | `20008` | `17777` | UDP |
+| Query | `20009` | `27015` | UDP |
 
-Icarus defaults are `17777/UDP` and `27015/UDP`; SlurpNet remaps them because
-`17777/UDP` is already Arma Reforger A2S and live Unraid currently binds
-`27015/UDP` for 7 Days to Die.
+The container binds Icarus defaults internally (`17777/UDP` game,
+`27015/UDP` query). Docker publishes them on SlurpNet host ports `20008` and
+`20009`, which is what UniFi forwards. The host scheme avoids two conflicts on
+this Unraid box: `17777/UDP` is already Arma Reforger A2S, and `27015/UDP` is
+bound by 7 Days to Die.
 
 ## Mod pak compatibility
 
@@ -80,10 +82,11 @@ password or admin password.
 
 Forward these UDP ports to the Unraid host `192.168.225.196`:
 
-- `17787/UDP`
-- `27017/UDP`
+- `20008/UDP` (game)
+- `20009/UDP` (query)
 
-Do not reuse Icarus defaults on the router.
+Do not reuse Icarus defaults on the router — `17777/UDP` and `27015/UDP` are
+owned by other game servers on this host.
 
 ## Local setup
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,25 +10,31 @@ services:
     cpuset: "32-47,96-111"
     mem_limit: 24g
     ports:
-      - "${GAME_PORT:-17787}:${GAME_PORT:-17787}/udp"
-      - "${QUERY_PORT:-27017}:${QUERY_PORT:-27017}/udp"
+      # Host-side published ports (GAME_PORT/QUERY_PORT) map to Icarus defaults
+      # inside the container (17777 game / 27015 query). The host scheme avoids
+      # conflicts with Arma Reforger (17777) and 7 Days to Die (27015) on the
+      # same Unraid box.
+      - "${GAME_PORT:-20008}:17777/udp"
+      - "${QUERY_PORT:-20009}:27015/udp"
     volumes:
       - /mnt/user/appdata/steamcmd:/serverdata/steamcmd
       - /mnt/cache/appdata/icarus:/serverdata/serverfiles
     environment:
       GAME_ID: "${GAME_ID:-2089300}"
-      # Verified in ich777 Unraid template.
+      # Verified in ich777 Unraid template. The container binds Icarus defaults
+      # internally; the host mapping above publishes them on the SlurpNet ports.
       GAME_PARAMS: >-
         -SteamServerName="${SERVER_NAME:-SlurpNet Icarus}"
-        -Port=${GAME_PORT:-17787}
-        -QueryPort=${QUERY_PORT:-27017}
+        -Port=17777
+        -QueryPort=27015
+        -log
       VALIDATE: "${VALIDATE:-}"
       UID: "${UID:-99}"
       GID: "${GID:-100}"
       # TODO verify env name: ich777's Icarus template does not document these
       # as native variables; deploy scripts render them into ServerSettings.ini.
-      GAME_PORT: "${GAME_PORT:-17787}"
-      QUERY_PORT: "${QUERY_PORT:-27017}"
+      GAME_PORT: "${GAME_PORT:-20008}"
+      QUERY_PORT: "${QUERY_PORT:-20009}"
       SERVER_NAME: "${SERVER_NAME:-SlurpNet Icarus}"
       SERVER_PASSWORD: "${SERVER_PASSWORD}"
       ADMIN_PASSWORD: "${ADMIN_PASSWORD}"

--- a/launcher/servers-entry.json
+++ b/launcher/servers-entry.json
@@ -18,8 +18,8 @@
   "launchArgs": [],
   "steamInstallDir": "Icarus",
   "serverSideOnly": false,
-  "serverPort": 17787,
-  "queryPort": 27017,
+  "serverPort": 20008,
+  "queryPort": 20009,
   "connectInstructions": "Install the SlurpNet Icarus pack via the launcher (single merged .pak required - weekly Icarus updates may force a re-pack). Launch Icarus from Steam, choose Open World > Join, find SlurpNet in the server browser, password required.",
   "sourceRepository": "https://github.com/zachyzissou/slurpnet-icarus",
   "modpack": {

--- a/pack.json
+++ b/pack.json
@@ -40,8 +40,8 @@
     "launchArgs": [],
     "steamInstallDir": "Icarus",
     "serverSideOnly": false,
-    "serverPort": 17787,
-    "queryPort": 27017,
+    "serverPort": 20008,
+    "queryPort": 20009,
     "sourceRepository": "https://github.com/zachyzissou/slurpnet-icarus"
   }
 }

--- a/scripts/validate-icarus-release.sh
+++ b/scripts/validate-icarus-release.sh
@@ -31,15 +31,15 @@ if [ "$missing" -ne 0 ]; then
   exit 1
 fi
 
-grep -q '^GAME_PORT=17787$' .env.example || { echo "ERROR: .env.example missing GAME_PORT=17787" >&2; exit 1; }
-grep -q '^QUERY_PORT=27017$' .env.example || { echo "ERROR: .env.example missing QUERY_PORT=27017" >&2; exit 1; }
+grep -q '^GAME_PORT=20008$' .env.example || { echo "ERROR: .env.example missing GAME_PORT=20008" >&2; exit 1; }
+grep -q '^QUERY_PORT=20009$' .env.example || { echo "ERROR: .env.example missing QUERY_PORT=20009" >&2; exit 1; }
 grep -q '^SERVER_PASSWORD=$' .env.example || { echo "ERROR: .env.example must keep SERVER_PASSWORD blank" >&2; exit 1; }
 grep -q '^ADMIN_PASSWORD=$' .env.example || { echo "ERROR: .env.example must keep ADMIN_PASSWORD blank" >&2; exit 1; }
 grep -q 'SERVER_NAME="SlurpNet Icarus"' .env.example || { echo "ERROR: .env.example missing server name" >&2; exit 1; }
 
 grep -q 'image: ich777/steamcmd:icarus' docker/docker-compose.yml || { echo "ERROR: compose image must use verified fallback" >&2; exit 1; }
-grep -q '\${GAME_PORT:-17787}:\${GAME_PORT:-17787}/udp' docker/docker-compose.yml || { echo "ERROR: compose missing game UDP port mapping" >&2; exit 1; }
-grep -q '\${QUERY_PORT:-27017}:\${QUERY_PORT:-27017}/udp' docker/docker-compose.yml || { echo "ERROR: compose missing query UDP port mapping" >&2; exit 1; }
+grep -q '\${GAME_PORT:-20008}:17777/udp' docker/docker-compose.yml || { echo "ERROR: compose missing game UDP port mapping (host 20008 -> container 17777)" >&2; exit 1; }
+grep -q '\${QUERY_PORT:-20009}:27015/udp' docker/docker-compose.yml || { echo "ERROR: compose missing query UDP port mapping (host 20009 -> container 27015)" >&2; exit 1; }
 grep -q 'cpuset: "32-47,96-111"' docker/docker-compose.yml || { echo "ERROR: compose missing SlurpNet CPU pinning" >&2; exit 1; }
 grep -q 'mem_limit: 24g' docker/docker-compose.yml || { echo "ERROR: compose missing 24g memory ceiling" >&2; exit 1; }
 


### PR DESCRIPTION
## Summary

The repo's port declarations diverged from the live container: repo said host 17787 (game) / 27017 (query) on both host and container; the live `Icarus` container has always published host **20008 -> container 17777** and host **20009 -> container 27015**, with `GAME_PARAMS=-Port=17777 -QueryPort=27015 -log` binding Icarus defaults inside the container. Both schemes work, but the live scheme is what UniFi and Steam are wired to, and it cleanly avoids two real host-port conflicts on this Unraid box (17777 is Arma Reforger A2S, 27015 is 7 Days to Die).

Converging the repo on the live scheme. **No runtime container changes** — this is purely repo-side cleanup.

## File-by-file changes

| File | Change |
|---|---|
| `docker/docker-compose.yml` | Port mappings now `${GAME_PORT:-20008}:17777/udp` and `${QUERY_PORT:-20009}:27015/udp`; `GAME_PARAMS` hardcoded to `-Port=17777 -QueryPort=27015 -log` (matches container internals); env defaults `GAME_PORT=20008`, `QUERY_PORT=20009`. CPU pinning, mem_limit, image, container_name, volumes, and other env preserved. |
| `.env.example` | `GAME_PORT=20008`, `QUERY_PORT=20009` with a comment that these are host-side. |
| `scripts/validate-icarus-release.sh` | Assertions updated: `.env.example` now expected to declare 20008/20009; compose grep now requires `20008:17777/udp` and `20009:27015/udp`. All other validations untouched. |
| `pack.json` | `serverPort: 20008`, `queryPort: 20009`. `version` untouched. |
| `launcher/servers-entry.json` | `serverPort: 20008`, `queryPort: 20009`. |
| `README.md` | Port table now has host and container columns. UniFi forward section updated to `20008/UDP` (game) and `20009/UDP` (query). Conflict explanation reworded for the new scheme. |
| `.github/workflows/icarus-live-check.yml` | `ss` port grep `:(17787\|27017)` -> `:(20008\|20009)`. This was the source of the current production failure on this workflow. |
| `AGENTS.md` | Stale port rule refreshed. |

## Test plan

- [x] `bash scripts/validate-icarus-release.sh` passes locally.
- [x] `docker/docker-compose.yml` parses as valid YAML; ports and `GAME_PARAMS` resolve to the live scheme.
- [x] `pack.json` and `launcher/servers-entry.json` parse as valid JSON.
- [x] No remaining references to `17787` / `27017` anywhere in the repo.
- [ ] After merge, manual dispatch of `icarus-live-check.yml` should now succeed on the port grep step.

Runtime container state is unchanged. Do not redeploy off this PR alone — the only deployable artifact change is the compose file, and a deploy would no-op the live ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)