### PR TITLE
Use docker port instead of ss in icarus-live-check

### DIFF
--- a/.github/workflows/icarus-live-check.yml
+++ b/.github/workflows/icarus-live-check.yml
@@ -14,7 +14,10 @@ jobs:
           timeout 15s docker ps --filter name=Icarus --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
           timeout 15s docker inspect Icarus --format 'name={{.Name}} image={{.Config.Image}} restart={{.HostConfig.RestartPolicy.Name}} cpuset={{.HostConfig.CpusetCpus}} memory={{.HostConfig.Memory}}'
           timeout 15s docker top Icarus -eo pid,ppid,comm,args | head -80 || true
-          timeout 15s ss -lunpt | grep -E ':(20008|20009)\b'
+          # ss is not installed in the runner container; use docker port to verify the published UDP mapping.
+          timeout 15s docker port Icarus | tee /tmp/icarus-port-map.txt
+          grep -E '^17777/udp -> .*:20008$' /tmp/icarus-port-map.txt
+          grep -E '^27015/udp -> .*:20009$' /tmp/icarus-port-map.txt
           test -f /mnt/cache/appdata/icarus/Icarus/Content/Paks/mods/SlurpNet.pak
           sha256sum /mnt/cache/appdata/icarus/Icarus/Content/Paks/mods/SlurpNet.pak
           timeout 15s docker logs --tail 160 Icarus || true


### PR DESCRIPTION
## Summary
The runner container doesn't have `iproute2`, so `ss` is not in PATH. Under `set -euo pipefail` the live-check step exits 1 with `timeout: failed to run command 'ss': No such file or directory` and the workflow fails.

PR #7 fixed the port numbers in the grep (17787/27017 → 20008/20009) but the `ss` binary itself was the root issue — that grep was never going to match because the command before the pipe didn't exist.

This swaps the listener probe for `docker port Icarus`, which uses the docker CLI we're already calling. Explicitly verifies the published UDP mapping is `17777/udp -> :20008` (game) and `27015/udp -> :20009` (query).

## Test plan
- [ ] Merge
- [ ] `gh workflow run icarus-live-check.yml -R zachyzissou/slurpnet-icarus -r main`
- [ ] All checks pass; workflow goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)