### PR TITLE
Load Slurplympus prospect + fix world name (Olympus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Current stable baseline:
 - image: `ich777/steamcmd:icarus`
 - server name: `SlurpNet Icarus`
 - mode: Open World, persistent
-- world: Prometheus
+- world: Olympus (prospect: `Slurplympus`, template `Outpost006_Olympus`)
 - max players: 8
 - appdata: `/mnt/cache/appdata/icarus/`
 - Steam server app: `2089300`

--- a/config/ServerSettings.ini
+++ b/config/ServerSettings.ini
@@ -8,7 +8,7 @@ ShutdownIfEmptyFor=-1
 AllowNonAdminsToLaunchProspects=False
 AllowNonAdminsToDeleteProspects=False
 ResumeProspect=True
-LoadProspect=
+LoadProspect=Slurplympus
 CreateProspect=
 LastProspectName=
 

--- a/launcher/servers-entry.json
+++ b/launcher/servers-entry.json
@@ -2,9 +2,9 @@
   "serverId": "icarus",
   "game": "Icarus",
   "name": "SlurpNet Icarus",
-  "description": "Co-op PvE survival on Prometheus. Open-world persistent server with the Comfortable mod tier - Icarus Plus, beacon teleport, item finder, cave master, kept trees, and 5x food buff.",
+  "description": "Co-op PvE survival on Olympus. Open-world persistent server (Slurplympus prospect) with the Comfortable mod tier - Icarus Plus, beacon teleport, item finder, cave master, kept trees, and 5x food buff.",
   "modCount": 6,
-  "worldName": "Prometheus",
+  "worldName": "Olympus",
   "maxPlayers": 8,
   "features": [
     "Open World",

--- a/pack.json
+++ b/pack.json
@@ -23,9 +23,9 @@
   },
   "launcher": {
     "name": "SlurpNet Icarus",
-    "description": "Co-op PvE survival on Prometheus. Open-world persistent server with the Comfortable mod tier — Icarus Plus, beacon teleport, item finder, cave master, kept trees, and 5x food buff.",
+    "description": "Co-op PvE survival on Olympus. Open-world persistent server (Slurplympus prospect) with the Comfortable mod tier — Icarus Plus, beacon teleport, item finder, cave master, kept trees, and 5x food buff.",
     "modCount": 6,
-    "worldName": "Prometheus",
+    "worldName": "Olympus",
     "maxPlayers": 8,
     "features": [
       "Open World",


### PR DESCRIPTION
## Summary
- **Server was invisible in the in-game browser** because no prospect was loaded. `ResumeProspect=True` but `LoadProspect=`, `CreateProspect=`, `LastProspectName=` were all empty. The server sat at `DedicatedServerEntry` with no joinable session and didn't register a presence anywhere.
- Set `LoadProspect=Slurplympus` to load the existing saved prospect at `/mnt/cache/appdata/icarus/Icarus/Saved/PlayerData/DedicatedServer/Prospects/Slurplympus.json` (template `Outpost006_Olympus`, saved 2026-04-29).
- Correct `worldName` drift in `pack.json`, `README.md`, and `launcher/servers-entry.json` — they all said "Prometheus" but the actual saved world is **Olympus**.

## Verified live
Tested against the running server with the same edits applied to the live ini:
- `LogWorldStats: Adding world stats for prospect: Outpost006_Olympus`
- `LogWorldBoss: Open World Stat (WorldIsOpenWorldProspect_?) found - prospect supports respawning!`
- `OnServerStartedEmpty()` → `Server is now empty` → `OnServerBecomeEmpty() Not returning to lobby`
- Memory: 1.8 GiB (no-prospect baseline) → **4.2 GiB** (Open World loaded)
- AI spawners: TrappedCreatures, Spider, RockGolem, RockGolem_Desert, RockGolem_Ice, Arctic_Bat, Caveworm_Spawner, Wild_Beehive_Tree, Wild_Kiwi_Nest
- 6 World Boss actors spawned
- A2S query from a remote host gets a challenge response on UDP 20009

## How I found the right prospect template name
`Outpost_005_Forest` (with underscore between Outpost and 005) returned `CreateNewProspect - Failed to find prospect`. The actual names live in `D_ProspectList.json` (recovered via MatthiasKunnen/icarus-pedia game data dump) and have NO underscore between "Outpost" and the number: `Outpost006_Olympus`, `OpenWorld_Prometheus`, `OpenWorld_Styx`, etc.

For this server, we already had a saved prospect from a prior session, so `LoadProspect=Slurplympus` (the filename without .json) is correct. `CreateProspect=OpenWorld_Prometheus` would also work for a fresh start but requires `ProspectIdOverride` to be specified for outposts.

## Test plan
- [ ] Merge PR
- [ ] `gh workflow run deploy-icarus.yml -R zachyzissou/slurpnet-icarus -r main` (sanity check that the deploy applies the new ini without breaking the running session)
- [ ] Open Icarus → Open World → Join → search "SlurpNet" — server appears
- [ ] Connect with the password and verify mods load
- [ ] Optionally trigger `icarus-live-check.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)