### PR TITLE
Symmetric port mapping for Steam Master registration

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,23 +10,28 @@ services:
     cpuset: "32-47,96-111"
     mem_limit: 24g
     ports:
-      # Host-side published ports (GAME_PORT/QUERY_PORT) map to Icarus defaults
-      # inside the container (17777 game / 27015 query). The host scheme avoids
-      # conflicts with Arma Reforger (17777) and 7 Days to Die (27015) on the
-      # same Unraid box.
-      - "${GAME_PORT:-20008}:17777/udp"
-      - "${QUERY_PORT:-20009}:27015/udp"
+      # SYMMETRIC port mapping is required for Steam Master Server registration.
+      # IcarusServer.exe advertises -Port and -QueryPort to the Steam Master, and
+      # Valve's master reaches the server via the public IP at THOSE port numbers.
+      # If host != container, Steam Master sends queries to ports nothing answers
+      # on, and the server never appears in the in-game Dedicated Servers tab.
+      # Arma Reforger owns host 17777 and SvenCoop owns host 27015 on this box,
+      # so we publish 20008/20009 host AND bind 20008/20009 container.
+      - "${GAME_PORT:-20008}:${GAME_PORT:-20008}/udp"
+      - "${QUERY_PORT:-20009}:${QUERY_PORT:-20009}/udp"
     volumes:
       - /mnt/user/appdata/steamcmd:/serverdata/steamcmd
       - /mnt/cache/appdata/icarus:/serverdata/serverfiles
     environment:
       GAME_ID: "${GAME_ID:-2089300}"
-      # Verified in ich777 Unraid template. The container binds Icarus defaults
-      # internally; the host mapping above publishes them on the SlurpNet ports.
+      # GAME_PARAMS -Port/-QueryPort must match the host-published ports (above).
+      # Do NOT use -MULTIHOME=<host-ip>: the container's network namespace does
+      # not contain the host's LAN IP, so IcarusServer.exe cannot bind to it.
+      # Bridge + symmetric ports + no MULTIHOME is the working combination.
       GAME_PARAMS: >-
         -SteamServerName="${SERVER_NAME:-SlurpNet Icarus}"
-        -Port=17777
-        -QueryPort=27015
+        -Port=${GAME_PORT:-20008}
+        -QueryPort=${QUERY_PORT:-20009}
         -log
       VALIDATE: "${VALIDATE:-}"
       UID: "${UID:-99}"

--- a/scripts/validate-icarus-release.sh
+++ b/scripts/validate-icarus-release.sh
@@ -38,8 +38,8 @@ grep -q '^ADMIN_PASSWORD=$' .env.example || { echo "ERROR: .env.example must kee
 grep -q 'SERVER_NAME="SlurpNet Icarus"' .env.example || { echo "ERROR: .env.example missing server name" >&2; exit 1; }
 
 grep -q 'image: ich777/steamcmd:icarus' docker/docker-compose.yml || { echo "ERROR: compose image must use verified fallback" >&2; exit 1; }
-grep -q '\${GAME_PORT:-20008}:17777/udp' docker/docker-compose.yml || { echo "ERROR: compose missing game UDP port mapping (host 20008 -> container 17777)" >&2; exit 1; }
-grep -q '\${QUERY_PORT:-20009}:27015/udp' docker/docker-compose.yml || { echo "ERROR: compose missing query UDP port mapping (host 20009 -> container 27015)" >&2; exit 1; }
+grep -q '\${GAME_PORT:-20008}:\${GAME_PORT:-20008}/udp' docker/docker-compose.yml || { echo "ERROR: compose missing symmetric game UDP port mapping (host:container both \${GAME_PORT:-20008})" >&2; exit 1; }
+grep -q '\${QUERY_PORT:-20009}:\${QUERY_PORT:-20009}/udp' docker/docker-compose.yml || { echo "ERROR: compose missing symmetric query UDP port mapping (host:container both \${QUERY_PORT:-20009})" >&2; exit 1; }
 grep -q 'cpuset: "32-47,96-111"' docker/docker-compose.yml || { echo "ERROR: compose missing SlurpNet CPU pinning" >&2; exit 1; }
 grep -q 'mem_limit: 24g' docker/docker-compose.yml || { echo "ERROR: compose missing 24g memory ceiling" >&2; exit 1; }
 


### PR DESCRIPTION
## Summary
Icarus dedi server's in-game browser visibility is gated by Steam Master Server. The master uses the **same port numbers the server advertises** when routing client queries back to it. With the previous asymmetric mapping (host 20008 → container 17777, host 20009 → container 27015) the server was telling Valve "I'm at port 27015" while the public-facing port was actually 20009 — so the master server's reachability probe failed and the server never registered.

This PR converts to symmetric mapping:
- `${GAME_PORT:-20008}:${GAME_PORT:-20008}/udp`
- `${QUERY_PORT:-20009}:${QUERY_PORT:-20009}/udp`
- `GAME_PARAMS -Port=${GAME_PORT:-20008} -QueryPort=${QUERY_PORT:-20009}`

Also adds inline comments explaining why MULTIHOME doesn't work on a Docker bridge (host LAN IP isn't in the container namespace) and why host networking is off-limits (Arma Reforger owns 17777, SvenCoop owns 27015).

## Verified
After recreating the live container with this exact config (`docker run` with `-p 20008:20008/udp -p 20009:20009/udp` and matching GAME_PARAMS), A2S query from a Mac on the LAN returned `name='SlurpNet Icarus' game='Icarus' players=0/8`. Server is healthy with Slurplympus prospect loaded. Unraid template `/boot/config/plugins/dockerMan/templates-user/my-Icarus.xml` was updated in lockstep.

## The remaining piece (NOT in this PR)
A2S from the public IP `47.186.229.92:20009` still times out — confirming UniFi has no port-forward rule for UDP 20008/20009 to 192.168.225.196. That's the actual final gate on browser visibility; operator needs to add the forwards in UniFi. The repo can't fix that; this PR just ensures the server side is correctly configured to take advantage of the forwards once they exist.

## Test plan
- [ ] Merge
- [ ] Verify no deploy regression (deploy.sh does `docker restart`, not recreate; this PR doesn't affect the running container's runtime)
- [ ] Operator adds UniFi port forwards (UDP 20008 + 20009 → 192.168.225.196)
- [ ] Wait 5–10 min for Steam Master Server propagation
- [ ] Search "SlurpNet" in Icarus → Open World → Join → Dedicated Servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)