### PR TITLE
Launch Icarus in DX12 mode via launcher

### DIFF
--- a/launcher/servers-entry.json
+++ b/launcher/servers-entry.json
@@ -15,7 +15,7 @@
     "No Grind"
   ],
   "steamAppId": 1149460,
-  "launchArgs": [],
+  "launchArgs": ["-dx12"],
   "steamInstallDir": "Icarus",
   "serverSideOnly": false,
   "serverPort": 20008,

--- a/pack.json
+++ b/pack.json
@@ -37,7 +37,7 @@
     ],
     "connectInstructions": "Install the SlurpNet Icarus pack via the launcher (single merged .pak required — weekly Icarus updates may force a re-pack). Launch Icarus from Steam, choose Open World > Join, find SlurpNet in the server browser, password required.",
     "steamAppId": 1149460,
-    "launchArgs": [],
+    "launchArgs": ["-dx12"],
     "steamInstallDir": "Icarus",
     "serverSideOnly": false,
     "serverPort": 20008,


### PR DESCRIPTION
## Summary
Sets `launchArgs: ["-dx12"]` in `pack.json` (and the kept-in-sync `launcher/servers-entry.json`). The SlurpNet launcher reads this and constructs `steam://run/1149460///-dx12/` when the user clicks Play, which tells Icarus to use the DirectX 12 renderer instead of the DX11 default.

## How it flows end-to-end
1. `pack.json.launcher.launchArgs` → `build-client-pack.py` writes it into the merged `servers.json` at `/mnt/cache/appdata/slurpnet-content-origin/api/servers.json` during deploy
2. mods.slurpgg.net serves that JSON
3. SlurpNet launcher fetches servers.json from the live API
4. User clicks Play on the Icarus card → `App.tsx` calls `window.electronAPI.launchGame(steamAppId, launchArgs)`
5. `electron/ipc/steam.ts` builds the Steam URL: `const args = launchArgs.length > 0 ? \`//${launchArgs.join(' ')}/\` : ''; const url = \`steam://run/${steamAppId}/${args}\``
6. Steam parses, launches Icarus with `-dx12`

## Why DX12 for Icarus
- UE4 4.27 (the Icarus engine version, per `LogInit: Build: ++UE4+Release-4.27-CL-0`) ships a working DX12 RHI
- DX12 lets the GPU driver schedule work in parallel with the render thread → less CPU bottleneck
- Especially helpful in our heavy open-world prospect with mods loaded
- No known Icarus-specific DX12 regressions

## Test plan
- [ ] Merge
- [ ] Deploy fires, build-client-pack publishes updated servers.json
- [ ] Restart SlurpNet launcher on a client machine (or wait for it to refresh)
- [ ] Click Play on the Icarus card
- [ ] Confirm Icarus boots with the DX12 splash (the engine's startup banner mentions D3D12 in the log)

If DX12 causes visual issues on a particular GPU, the user can override locally via Steam's Launch Options for Icarus (those take precedence over `steam://run` args in some Steam client versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)