### PR TITLE
Include launchArgs in public launcher feed

### DIFF
--- a/scripts/build-client-pack.py
+++ b/scripts/build-client-pack.py
@@ -48,14 +48,19 @@ def build_entry(pack: dict, zip_size: int, private: bool) -> dict:
             "version": pack["version"],
             "size": zip_size,
         },
+        # launchArgs / steamInstallDir / serverSideOnly are NOT secret — they're
+        # CLI flags + filesystem hints the launcher uses to actually start the
+        # game. Keep them in the public entry so the launcher (which fetches
+        # mods.slurpgg.net/api/servers.json — see slurpnet-launcher
+        # electron/ipc/servers.ts) can read them without auth.
+        "launchArgs": launcher.get("launchArgs", []),
+        "steamInstallDir": launcher["steamInstallDir"],
+        "serverSideOnly": launcher["serverSideOnly"],
     }
     if private:
         entry.update(
             {
                 "password": os.environ.get("SLURPNET_LAUNCHER_PASSWORD", ""),
-                "launchArgs": launcher.get("launchArgs", []),
-                "steamInstallDir": launcher["steamInstallDir"],
-                "serverSideOnly": launcher["serverSideOnly"],
             }
         )
         entry["modpack"].update(


### PR DESCRIPTION
## Summary
`scripts/build-client-pack.py` only included `launchArgs`, `steamInstallDir`, and `serverSideOnly` in the **private** launcher feed (`launcher-servers.json`). But the SlurpNet launcher actually fetches the **public** feed (`https://mods.slurpgg.net/api/servers.json` per `slurpnet-launcher/electron/ipc/servers.ts:4`). Result: `launchArgs=["-dx12"]` set in PR #12 reached the private feed but never the launcher.

Move those three fields to the always-included branch. None of them are secret — they're a CLI flag list, the Steam folder name, and a UI hint. Only `password` (and the live modpack URLs) need to stay private-only.

## Verified before this PR
After PR #12 (`launchArgs=["-dx12"]` in pack.json) merged and deploy-icarus.yml ran successfully, the live launcher-side feed showed:
- `launcher-servers.json` (private): `launchArgs: ["-dx12"]` ✓
- `servers.json` (public, what the launcher actually fetches): `launchArgs` MISSING ✗

## Test plan
- [ ] Merge
- [ ] Deploy fires; build-client-pack regenerates both feeds
- [ ] `curl -s https://mods.slurpgg.net/api/servers.json | jq '.servers[] | select(.game=="Icarus") | .launchArgs'` returns `["-dx12"]`
- [ ] User refreshes/restarts SlurpNet launcher
- [ ] Click Play on Icarus card → Steam launches Icarus with `-dx12`
- [ ] In Icarus, check that the renderer is D3D12 (visible in `Icarus/Saved/Logs/Icarus.log` line `LogD3D12RHI:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)