### PR TITLE
Persist LoadProspect=Slurplympus in render script

### DIFF
--- a/scripts/render-server-settings.sh
+++ b/scripts/render-server-settings.sh
@@ -18,6 +18,17 @@ set +a
 : "${SERVER_PASSWORD:?SERVER_PASSWORD is required}"
 : "${ADMIN_PASSWORD:?ADMIN_PASSWORD is required}"
 : "${MAX_PLAYERS:=8}"
+# LoadProspect names a saved prospect under
+# Icarus/Saved/PlayerData/DedicatedServer/Prospects/<NAME>.json. Without it
+# the server boots into the entry map and the in-game Load/New buttons are
+# greyed for non-admin players, so the operator-curated world never starts.
+: "${LOAD_PROSPECT:=Slurplympus}"
+# Allow any password-authed player to load/create a prospect. With this
+# False, players who join without admin rights can only sit in the lobby.
+# The server is password-protected at the join step already, so opening up
+# prospect launch is appropriate for a small private server.
+: "${ALLOW_NON_ADMINS_TO_LAUNCH_PROSPECTS:=True}"
+: "${ALLOW_NON_ADMINS_TO_DELETE_PROSPECTS:=False}"
 
 cat > "$OUT_FILE" <<EOF
 [/Script/Icarus.DedicatedServerSettings]
@@ -27,10 +38,10 @@ MaxPlayers=${MAX_PLAYERS}
 AdminPassword=${ADMIN_PASSWORD}
 ShutdownIfNotJoinedFor=-1
 ShutdownIfEmptyFor=-1
-AllowNonAdminsToLaunchProspects=False
-AllowNonAdminsToDeleteProspects=False
+AllowNonAdminsToLaunchProspects=${ALLOW_NON_ADMINS_TO_LAUNCH_PROSPECTS}
+AllowNonAdminsToDeleteProspects=${ALLOW_NON_ADMINS_TO_DELETE_PROSPECTS}
 ResumeProspect=True
-LoadProspect=
+LoadProspect=${LOAD_PROSPECT}
 CreateProspect=
 LastProspectName=
 


### PR DESCRIPTION
## Summary
`render-server-settings.sh` writes a hardcoded `LoadProspect=` (empty) and `AllowNonAdminsToLaunchProspects=False` regardless of the repo template. Since the deploy workflow uses this script's output to overwrite the live `config/ServerSettings.ini`, every deploy resets the prospect setting and locks the lobby. PR #10's template edit was effectively no-op.

This PR parameterizes both settings with SlurpNet defaults:
- `LOAD_PROSPECT=${LOAD_PROSPECT:=Slurplympus}`
- `ALLOW_NON_ADMINS_TO_LAUNCH_PROSPECTS=${ALLOW_NON_ADMINS_TO_LAUNCH_PROSPECTS:=True}`

Both overridable via env at deploy time.

## Symptom this fixes
Player joins → lobby → Load / New buttons greyed → can't enter the world. Server log shows `AddConnectedPlayer` followed by `RemoveConnectedPlayer` after the client times out.

## Verified before this PR
Applied the same values directly to the live ini and restarted the container — Slurplympus auto-loaded (World Bosses spawned, OnServerStartedEmpty), and the lobby buttons unlocked for non-admin Steam users. Without this PR, the next deploy would revert and break the lobby again.

## Test plan
- [ ] Merge
- [ ] Deploy fires, render writes `LoadProspect=Slurplympus` + `AllowNonAdminsToLaunchProspects=True`
- [ ] `ssh ... 'grep -E "Load|Allow" /mnt/cache/appdata/icarus/Icarus/Saved/Config/WindowsServer/ServerSettings.ini'` returns the expected values
- [ ] Reconnect to server; Load/New are no longer greyed; Slurplympus loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)