### PR TITLE
Reconcile existing Icarus container before compose

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -86,6 +86,7 @@ run_compose() {
 if docker inspect "$CONTAINER" >/dev/null 2>&1; then
   if [ "$RECONCILE_CONTAINER" = "1" ]; then
     echo "ICARUS_RECONCILE_CONTAINER=1; recreating $CONTAINER from docker/docker-compose.yml..."
+    docker rm -f "$CONTAINER" >/dev/null
     run_compose
   else
     echo "Restarting existing $CONTAINER. Set ICARUS_RECONCILE_CONTAINER=1 to recreate from compose."


### PR DESCRIPTION
## Summary
- remove the existing named `Icarus` container before compose reconciliation when `ICARUS_RECONCILE_CONTAINER=1`
- fixes the production deploy failure where Compose could not create `Icarus` because a legacy container already owned that name
- leaves non-reconcile deploys as restart-only

## Verification
- `shellcheck scripts/deploy.sh`
- `bash -n scripts/deploy.sh`
- `scripts/validate-icarus-release.sh`
- `git diff --check`