### PR TITLE
Enforce Icarus memory limit in deploy checks

### DIFF
--- a/.github/workflows/icarus-live-check.yml
+++ b/.github/workflows/icarus-live-check.yml
@@ -17,6 +17,7 @@ jobs:
           set -euo pipefail
           timeout 15s docker ps --filter name=Icarus --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
           timeout 15s docker inspect Icarus --format 'name={{.Name}} image={{.Config.Image}} restart={{.HostConfig.RestartPolicy.Name}} cpuset={{.HostConfig.CpusetCpus}} memory={{.HostConfig.Memory}}'
+          test "$(timeout 15s docker inspect Icarus --format '{{.HostConfig.Memory}}')" = "25769803776"
           timeout 15s docker top Icarus -eo pid,ppid,comm,args | head -80 || true
           # ss is not installed in the runner container; use docker port to verify the published UDP mapping.
           timeout 15s docker port Icarus | tee /tmp/icarus-port-map.txt

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,6 +10,7 @@ GAME_PORT="${GAME_PORT:-20008}"
 QUERY_PORT="${QUERY_PORT:-20009}"
 SERVER_NAME="${SERVER_NAME:-SlurpNet Icarus}"
 RECONCILE_CONTAINER="${ICARUS_RECONCILE_CONTAINER:-0}"
+MEMORY_LIMIT="${ICARUS_MEMORY_LIMIT:-24g}"
 
 export APPDATA_ROOT="$APPDATA"
 export GAME_PORT QUERY_PORT SERVER_NAME
@@ -60,7 +61,7 @@ run_compose() {
     --name "$CONTAINER"
     --restart unless-stopped
     --cpuset-cpus "32-47,96-111"
-    --memory 24g
+    --memory "$MEMORY_LIMIT"
     -e GAME_ID="${GAME_ID:-2089300}"
     -e "GAME_PARAMS=-SteamServerName=\"${SERVER_NAME}\" -Port=${GAME_PORT} -QueryPort=${QUERY_PORT} -log"
     -e VALIDATE="${VALIDATE:-}"
@@ -99,6 +100,9 @@ fi
 
 echo "Verifying container is running..."
 docker inspect -f '{{.State.Running}}' "$CONTAINER" | grep -q '^true$'
+
+echo "Applying memory ceiling..."
+docker update --memory "$MEMORY_LIMIT" --memory-swap -1 "$CONTAINER" >/dev/null
 
 echo "Verifying published UDP ports..."
 docker port "$CONTAINER" | tee /tmp/icarus-port-map.txt

--- a/scripts/validate-icarus-release.sh
+++ b/scripts/validate-icarus-release.sh
@@ -53,6 +53,9 @@ grep -q '\${STEAMCMD_ROOT:-/mnt/user/appdata/steamcmd}:/serverdata/steamcmd' doc
 grep -q '\${APPDATA_ROOT:-/mnt/cache/appdata/icarus}:/serverdata/serverfiles' docker/docker-compose.yml || { echo "ERROR: compose must honor APPDATA_ROOT" >&2; exit 1; }
 grep -q 'ICARUS_RECONCILE_CONTAINER=1' scripts/deploy.sh || { echo "ERROR: deploy script must keep container reconciliation explicit" >&2; exit 1; }
 grep -q 'docker run' scripts/deploy.sh || { echo "ERROR: deploy script must support Unraid hosts without docker compose" >&2; exit 1; }
+grep -q 'MEMORY_LIMIT="${ICARUS_MEMORY_LIMIT:-24g}"' scripts/deploy.sh || { echo "ERROR: deploy script must default ICARUS_MEMORY_LIMIT to 24g" >&2; exit 1; }
+grep -q -- '--memory "$MEMORY_LIMIT"' scripts/deploy.sh || { echo "ERROR: docker run fallback must use MEMORY_LIMIT" >&2; exit 1; }
+grep -q 'docker update --memory "$MEMORY_LIMIT" --memory-swap -1 "$CONTAINER"' scripts/deploy.sh || { echo "ERROR: deploy script must enforce live container memory limit after reconcile" >&2; exit 1; }
 grep -q -- '-p "${GAME_PORT}:${GAME_PORT}/udp"' scripts/deploy.sh || { echo "ERROR: docker run fallback must use symmetric game port" >&2; exit 1; }
 grep -q -- '-p "${QUERY_PORT}:${QUERY_PORT}/udp"' scripts/deploy.sh || { echo "ERROR: docker run fallback must use symmetric query port" >&2; exit 1; }
 ! grep -q 'RCON_PORT' scripts/deploy.sh || { echo "ERROR: deploy script must not publish unproven Icarus TCP RCON" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- default deploy memory enforcement to `ICARUS_MEMORY_LIMIT=24g`
- apply the Docker memory limit after reconcile/restart so live drift is corrected during deploy
- make live-check fail if the Icarus container memory cap is not 24 GiB

## Verification
- `shellcheck scripts/deploy.sh scripts/validate-icarus-release.sh`
- `bash -n scripts/deploy.sh scripts/validate-icarus-release.sh`
- `scripts/validate-icarus-release.sh`
- workflow YAML parse for `.github/workflows/icarus-live-check.yml`
- `git diff --check`
- live corrected with `docker update --memory 24g --memory-swap -1 Icarus` and verified `memory=25769803776`