### PR TITLE
Harden Icarus memory enforcement fallback

### DIFF
--- a/.github/workflows/icarus-live-check.yml
+++ b/.github/workflows/icarus-live-check.yml
@@ -15,9 +15,11 @@ jobs:
       - name: Inspect Icarus container
         run: |
           set -euo pipefail
+          expected_memory_gib=24
           timeout 15s docker ps --filter name=Icarus --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
           timeout 15s docker inspect Icarus --format 'name={{.Name}} image={{.Config.Image}} restart={{.HostConfig.RestartPolicy.Name}} cpuset={{.HostConfig.CpusetCpus}} memory={{.HostConfig.Memory}}'
-          test "$(timeout 15s docker inspect Icarus --format '{{.HostConfig.Memory}}')" = "25769803776"
+          memory_bytes="$(timeout 15s docker inspect Icarus --format '{{.HostConfig.Memory}}')"
+          test "$((memory_bytes / 1024 / 1024 / 1024))" -eq "$expected_memory_gib"
           timeout 15s docker top Icarus -eo pid,ppid,comm,args | head -80 || true
           # ss is not installed in the runner container; use docker port to verify the published UDP mapping.
           timeout 15s docker port Icarus | tee /tmp/icarus-port-map.txt

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -84,6 +84,14 @@ run_compose() {
   docker run "${run_args[@]}" ich777/steamcmd:icarus
 }
 
+apply_memory_limit() {
+  if docker update --memory "$MEMORY_LIMIT" --memory-swap -1 "$CONTAINER" >/dev/null 2>&1; then
+    return
+  fi
+  echo "WARNING: docker could not apply --memory-swap=-1; applying --memory only." >&2
+  docker update --memory "$MEMORY_LIMIT" "$CONTAINER" >/dev/null
+}
+
 if docker inspect "$CONTAINER" >/dev/null 2>&1; then
   if [ "$RECONCILE_CONTAINER" = "1" ]; then
     echo "ICARUS_RECONCILE_CONTAINER=1; recreating $CONTAINER from docker/docker-compose.yml..."
@@ -102,7 +110,7 @@ echo "Verifying container is running..."
 docker inspect -f '{{.State.Running}}' "$CONTAINER" | grep -q '^true$'
 
 echo "Applying memory ceiling..."
-docker update --memory "$MEMORY_LIMIT" --memory-swap -1 "$CONTAINER" >/dev/null
+apply_memory_limit
 
 echo "Verifying published UDP ports..."
 docker port "$CONTAINER" | tee /tmp/icarus-port-map.txt

--- a/scripts/validate-icarus-release.sh
+++ b/scripts/validate-icarus-release.sh
@@ -53,9 +53,9 @@ grep -q '\${STEAMCMD_ROOT:-/mnt/user/appdata/steamcmd}:/serverdata/steamcmd' doc
 grep -q '\${APPDATA_ROOT:-/mnt/cache/appdata/icarus}:/serverdata/serverfiles' docker/docker-compose.yml || { echo "ERROR: compose must honor APPDATA_ROOT" >&2; exit 1; }
 grep -q 'ICARUS_RECONCILE_CONTAINER=1' scripts/deploy.sh || { echo "ERROR: deploy script must keep container reconciliation explicit" >&2; exit 1; }
 grep -q 'docker run' scripts/deploy.sh || { echo "ERROR: deploy script must support Unraid hosts without docker compose" >&2; exit 1; }
-grep -q 'MEMORY_LIMIT="${ICARUS_MEMORY_LIMIT:-24g}"' scripts/deploy.sh || { echo "ERROR: deploy script must default ICARUS_MEMORY_LIMIT to 24g" >&2; exit 1; }
-grep -q -- '--memory "$MEMORY_LIMIT"' scripts/deploy.sh || { echo "ERROR: docker run fallback must use MEMORY_LIMIT" >&2; exit 1; }
-grep -q 'docker update --memory "$MEMORY_LIMIT" --memory-swap -1 "$CONTAINER"' scripts/deploy.sh || { echo "ERROR: deploy script must enforce live container memory limit after reconcile" >&2; exit 1; }
+grep -Eq 'MEMORY_LIMIT=.*ICARUS_MEMORY_LIMIT:-24g' scripts/deploy.sh || { echo "ERROR: deploy script must default ICARUS_MEMORY_LIMIT to 24g" >&2; exit 1; }
+grep -Eq -- '--memory[[:space:]]+"?\$MEMORY_LIMIT"?' scripts/deploy.sh || { echo "ERROR: docker run fallback must use MEMORY_LIMIT" >&2; exit 1; }
+grep -Eq 'docker update .*--memory[[:space:]]+"?\$MEMORY_LIMIT"?' scripts/deploy.sh || { echo "ERROR: deploy script must enforce live container memory limit after reconcile" >&2; exit 1; }
 grep -q -- '-p "${GAME_PORT}:${GAME_PORT}/udp"' scripts/deploy.sh || { echo "ERROR: docker run fallback must use symmetric game port" >&2; exit 1; }
 grep -q -- '-p "${QUERY_PORT}:${QUERY_PORT}/udp"' scripts/deploy.sh || { echo "ERROR: docker run fallback must use symmetric query port" >&2; exit 1; }
 ! grep -q 'RCON_PORT' scripts/deploy.sh || { echo "ERROR: deploy script must not publish unproven Icarus TCP RCON" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- address Copilot comments from #23
- gracefully fall back to `docker update --memory` when `--memory-swap=-1` is unsupported
- validate memory behavior with resilient grep patterns
- make live-check compare the container cap in GiB instead of a magic byte literal

## Verification
- `shellcheck scripts/deploy.sh scripts/validate-icarus-release.sh`
- `bash -n scripts/deploy.sh scripts/validate-icarus-release.sh`
- `scripts/validate-icarus-release.sh`
- extracted live-check script passes `bash -n`
- `git diff --check`