### PR TITLE
Address Icarus memory review follow-up

### DIFF
--- a/.github/workflows/icarus-live-check.yml
+++ b/.github/workflows/icarus-live-check.yml
@@ -16,10 +16,11 @@ jobs:
         run: |
           set -euo pipefail
           expected_memory_gib=24
+          expected_memory_bytes="$((expected_memory_gib * 1024 * 1024 * 1024))"
           timeout 15s docker ps --filter name=Icarus --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
           timeout 15s docker inspect Icarus --format 'name={{.Name}} image={{.Config.Image}} restart={{.HostConfig.RestartPolicy.Name}} cpuset={{.HostConfig.CpusetCpus}} memory={{.HostConfig.Memory}}'
           memory_bytes="$(timeout 15s docker inspect Icarus --format '{{.HostConfig.Memory}}')"
-          test "$((memory_bytes / 1024 / 1024 / 1024))" -eq "$expected_memory_gib"
+          test "$memory_bytes" -eq "$expected_memory_bytes"
           timeout 15s docker top Icarus -eo pid,ppid,comm,args | head -80 || true
           # ss is not installed in the runner container; use docker port to verify the published UDP mapping.
           timeout 15s docker port Icarus | tee /tmp/icarus-port-map.txt

--- a/scripts/validate-icarus-release.sh
+++ b/scripts/validate-icarus-release.sh
@@ -56,6 +56,7 @@ grep -q 'docker run' scripts/deploy.sh || { echo "ERROR: deploy script must supp
 grep -Eq 'MEMORY_LIMIT=.*ICARUS_MEMORY_LIMIT:-24g' scripts/deploy.sh || { echo "ERROR: deploy script must default ICARUS_MEMORY_LIMIT to 24g" >&2; exit 1; }
 grep -Eq -- '--memory[[:space:]]+"?\$MEMORY_LIMIT"?' scripts/deploy.sh || { echo "ERROR: docker run fallback must use MEMORY_LIMIT" >&2; exit 1; }
 grep -Eq 'docker update .*--memory[[:space:]]+"?\$MEMORY_LIMIT"?' scripts/deploy.sh || { echo "ERROR: deploy script must enforce live container memory limit after reconcile" >&2; exit 1; }
+grep -Eq 'docker update .*--memory-swap[[:space:]]+-1' scripts/deploy.sh || { echo "ERROR: deploy script must attempt unlimited memory-swap before fallback" >&2; exit 1; }
 grep -q -- '-p "${GAME_PORT}:${GAME_PORT}/udp"' scripts/deploy.sh || { echo "ERROR: docker run fallback must use symmetric game port" >&2; exit 1; }
 grep -q -- '-p "${QUERY_PORT}:${QUERY_PORT}/udp"' scripts/deploy.sh || { echo "ERROR: docker run fallback must use symmetric query port" >&2; exit 1; }
 ! grep -q 'RCON_PORT' scripts/deploy.sh || { echo "ERROR: deploy script must not publish unproven Icarus TCP RCON" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- address Copilot comments from #24
- compute expected 24 GiB live-check bytes from the GiB value before comparing exactly
- keep release validation explicit that deploy attempts `--memory-swap -1` before fallback

## Verification
- `shellcheck scripts/deploy.sh scripts/validate-icarus-release.sh`
- `bash -n scripts/deploy.sh scripts/validate-icarus-release.sh`
- `scripts/validate-icarus-release.sh`
- extracted live-check script passes `bash -n`
- `git diff --check`